### PR TITLE
Corrected issue for projects that don't have Loadash globally defined.

### DIFF
--- a/grapher-vue.js
+++ b/grapher-vue.js
@@ -1,4 +1,5 @@
-const _ = require('lodash')
+const _ = require('lodash');
+
 export default {
 	install(Vue, options){
 		Vue.mixin({

--- a/grapher-vue.js
+++ b/grapher-vue.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 export default {
 	install(Vue, options){
 		Vue.mixin({

--- a/package.js
+++ b/package.js
@@ -15,5 +15,6 @@ Package.onUse(function(api) {
 });
 
 Npm.depends({
-	"vue-meteor-tracker": "1.2.3"
+	"vue-meteor-tracker": "1.2.3",
+	"lodash": "4.17.4",
 })


### PR DESCRIPTION
Grapher-Vue appears to be using Loadash. However, Lodash isn't imported nor is it in the package dependencies.
I went ahead and added Lodash as an NPM dependency and added a `require()` for it in `grapher-vue.js`